### PR TITLE
Fix typos and docstring, add gauge tests

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@
 
 import calendar
 from contextlib import closing
+import functools
 import logging
 import re
 import signal
@@ -109,7 +110,7 @@ class memoized(object):
          self.cache[args] = value
          return value
       except TypeError:
-         # uncachable -- for instance, passing a list as an argument.
+         # uncacheable -- for instance, passing a list as an argument.
          # Better to not cache than to blow up entirely.
          return self.func(*args)
    def __repr__(self):
@@ -124,6 +125,7 @@ def clean_key(key):
     '''
     Replace whitespace with '_', '/' with '-', and remove all
     non-alphanumerics remaining (except '.', '_', and '-').
+    The cleaned key is returned in lowercase.
 
     '''
     new_key = re.sub('''\s+''', '_', key)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,7 @@
 # Path hack.
 import sys
 import os
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import server
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -75,16 +75,23 @@ class ServerTestSuite(unittest.TestCase):
         server.add_metric('test.key', 1.0, 'ms', 1.0)
         self.assertEqual(server.metrics['ms']['test.key'], [1.0, 1.0])
 
+        server.add_metric('gauge.key', 2.0, 'g', 1.0)
+        self.assertEqual(server.metrics['g']['gauge.key'], [2.0])
+        server.add_metric('gauge.key', 4.0, 'g', 1.0)
+        self.assertEqual(server.metrics['g']['gauge.key'], [2.0, 4.0])
+
     def test_process_lines(self):
         lines = [
             'test.key: 1|c\n',
             'badline',
             'test.key: 2|c\n',
             'test.key2: 20|ms\n',
+            'test.gauge: 10|g\n',
             ]
         server.process_lines(lines)
         self.assertEqual(server.metrics['c']['test.key'], [1.0, 2.0])
         self.assertEqual(server.metrics['ms']['test.key2'], [20.0])
+        self.assertEqual(server.metrics['g']['test.gauge'], [10.0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- import `functools` for the `memoized` decorator
- fix typo in `memoized` comment
- document lowercase conversion in `clean_key`
- test gauge metrics in `add_metric` and `process_lines`

## Testing
- `python -m pytest -q` *(fails: SyntaxError because Python2 code runs under Python3)*

------
https://chatgpt.com/codex/tasks/task_e_684771d1aa648329b6cc295440b103da