### PR TITLE
Fix counter parse test tuple

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,7 +46,7 @@ class ServerTestSuite(unittest.TestCase):
         self.assertEqual(metric, ('test.key', 1.0, 'c', 1.0))
 
         metric = server.parse_line('test.key: 1|c|@0.1')
-        self.assertEqual(metric, (('test.key', 1.0, 'c', 0.1)))
+        self.assertEqual(metric, ('test.key', 1.0, 'c', 0.1))
 
         line = 'test.key: 1|c|2'
         self.assertRaises(ValueError, server.parse_line, line)


### PR DESCRIPTION
## Summary
- fix tuple formatting in parse_line_counter test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b9778c3c8832995b0fbf5e5f28933